### PR TITLE
feat: add `zsh-ssh-agent` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ All of these plugins are compatible with the [**:zap: Zap**](https://www.zapzsh.
 -   [zsh-oh-my-posh](https://github.com/wintermi/zsh-oh-my-posh) - A zsh plugin to manage the [Oh My Posh](https://ohmyposh.dev/) prompt theme engine.
 -   [zsh-fvm](https://github.com/olrtg/zsh-fvm) - A simple `fvm` (Flutter Version Manager) plugin for zsh.
 -   [zsh-kubectl](https://github.com/chrishrb/zsh-kubectl) - A zsh plugin for the kubectl cli.
+-   [zsh-ssh-agent](https://github.com/sdiebolt/zsh-ssh-agent) - A Zsh plugin that starts `ssh-agent` automatically.
 -   [git-alias](https://github.com/chivalryq/git-alias) - A zsh plugin for lots of handy git alias
 -   [zsh-autojump](https://github.com/chivalryq/zsh-autojump) - A zsh plugin for autojump
 -   [zsh-you-should-use](https://github.com/MichaelAquilina/zsh-you-should-use) - 📎 ZSH plugin that reminds you to use existing aliases for commands you just typed


### PR DESCRIPTION
I could not find a way to install the `ssh-agent` plugin from Oh My Zsh using ⚡ Zap since it's not a standalone repository, so I created a slightly shortened standalone fork. Let me know if anything needs changing! 